### PR TITLE
Updates SecretTemplate schema

### DIFF
--- a/.env
+++ b/.env
@@ -7,7 +7,7 @@ GOBASE=$(shell pwd)
 GOPATH=$(GOBASE)/vendor:$(GOBASE) # You can remove or change the path after last colon.
 GOBIN=$(GOBASE)/bin
 GOFILES=$(wildcard *.go)
-GOTESTS=$(shell find . -name "*_test.go" | grep -v vendor)
+GOTESTS=$(shell find . -name "*_test.go" | grep -v vendor | xargs -I{} dirname {} | sed -E "s/[.]/argocd-plugin-key-protect/g")
 VERSION=v0.0.0
 
 # Redirect error output to a file, so we can show it in development mode.

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -24,12 +24,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          go get -d -v ./...
-          go install -v ./...
+          make build
+          make install
 
       - name: Test
         run: |
-          go test $(find . -name "*_test.go" | grep -v vendor)
+          make test
 
   release:
     #    if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -24,8 +24,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          make build
-          make install
+          go mod vendor
+          go get -d -v ./...
+          go install -v ./...
 
       - name: Test
         run: |

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ go-clean:
 	@GOPATH=$(GOPATH) GOBIN=$(GOBIN) go clean
 
 go-test:
-	@echo "  >  Testing code"
+	@echo "  >  Testing code: $(GOTESTS)"
 	@GOPATH=$(GOPATH) GOBIN=$(GOBIN) go test $(GOTESTS)
 
 ## install: Install missing dependencies. Runs `go get` internally.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ metadata:
   name: mysecret
   annotations:
     key-manager: key-protect
+    key-protect/instanceId: instance-id
+    key-protect/region: us-east
 spec:
   labels: {}
   annotations: {}
@@ -46,7 +48,12 @@ spec:
       keyId: 36397b07-d98d-4c0b-bd7a-d6c290163684
 ``` 
 
-- The `metadata.annotations` value is optional and the only values supported currently for `key-manager` is `key-protect`
+- The `metadata.annotations` value is optional. 
+
+    - `key-manager` - the only value supported currently is `key-protect`
+    - `key-protect/instanceId` - the instance id of the key protect instance. If not provided then the `instance-id` value from the `key-protect-access` secret will be used.
+    - `key-protect/region` - the region where the key protect instance has been provisioned. If not provided then the `region` value from the `key-protect-access` secret will be used.
+    
 - The `metadata.name` value given will be used as the name for the Secret that will be generated.
 - The information in `spec.labels` and `spec.annotations` will be copied over as the `labels` and `annotations` in the Secret that is generated
 - The `spec.values` section contains the information that should be provided in the `data` section of the generated Secret. There are three prossible ways the values can be provided:
@@ -109,9 +116,14 @@ desired for managing the secrets. Currently only one Key Protect instance is sup
 ### Key Protect credentials
 
 In order to connect with Key Protect you will need three pieces of information:
+
 - `IBM Cloud API Key` - an API Key that has `Reader` and `ReaderPlus` access to the Key Protect instance
 - `Key Protect region` - the region where the Key Protect instance has been deployed
 - `Key Protect instance id` - the GUID of the Key Protect instance where the secrets are stored
+
+The three values can be provided in a secret named `key-protect-access` in the same namespace where ArgoCD has been deployed. As shown above,
+the region and instance id values can be provided in the SecretTemplate configuration. Additionally, the default API Key will be used
+from the `cloud-access` secret if the value is not available from the `key-protect-access` secret.
 
 #### Get the instance id for Key Protect
 

--- a/hack/install-plugin-dependencies-patch.json
+++ b/hack/install-plugin-dependencies-patch.json
@@ -49,11 +49,20 @@
       }
     }
   }, {
-    "name": "API_KEY",
+    "name": "KP_API_KEY",
     "valueFrom": {
       "secretKeyRef": {
         "name": "key-protect-access",
         "key": "api-key",
+        "optional": true
+      }
+    }
+  }, {
+    "name": "API_KEY",
+    "valueFrom": {
+      "secretKeyRef": {
+        "name": "cloud-access",
+        "key": "APIKEY",
         "optional": true
       }
     }

--- a/models/keyprotect_secret/main_test.go
+++ b/models/keyprotect_secret/main_test.go
@@ -1,0 +1,26 @@
+package keyprotect_secret
+
+import (
+	"argocd-plugin-key-protect/util/test_support"
+	"io/ioutil"
+	"testing"
+)
+
+func TestCanary(t *testing.T) {
+	if false {
+		t.Errorf("Canary failed")
+	}
+}
+
+func TestFromYaml(t *testing.T) {
+
+	yamlBytes, err := ioutil.ReadFile("../../test/secret-in.yaml")
+	if err != nil {
+		panic(err)
+	}
+
+	got := FromYaml(yamlBytes)
+	test_support.ExpectEqual(t, "mysecret", got.Metadata.Name)
+	test_support.ExpectNotEmpty(t, &got.Metadata.Annotations, "annotations")
+	test_support.ExpectEqualInt(t, len(got.Spec.Values), 3)
+}

--- a/models/kubernetes/main_test.go
+++ b/models/kubernetes/main_test.go
@@ -1,0 +1,38 @@
+package kubernetes
+
+import (
+	metadata2 "argocd-plugin-key-protect/models/metadata"
+	"argocd-plugin-key-protect/util/test_support"
+	"testing"
+)
+
+func TestCanary(t *testing.T) {
+	if false {
+		t.Errorf("Canary failed")
+	}
+}
+
+func TestAsYaml(t *testing.T) {
+
+	name := "test"
+	labels := make(map[string]string)
+	annotations := make(map[string]string)
+	metadata := metadata2.New(name, labels, annotations)
+
+	values := make(map[string]string)
+
+	values["test"] = "value"
+
+	secrets := []Secret{New(metadata, values)}
+	expected := `---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test
+data:
+  test: value
+`
+
+	got := AsYaml(secrets)
+	test_support.ExpectEqual(t, expected, got)
+}

--- a/test/secret-in.yaml
+++ b/test/secret-in.yaml
@@ -4,6 +4,8 @@ metadata:
   name: mysecret
   annotations:
     key-manager: key-protect
+    key-protect/instanceId: instance-id
+    key-protect/region: us-east
 spec:
   labels: {}
   annotations: {}

--- a/util/test_support/main.go
+++ b/util/test_support/main.go
@@ -1,0 +1,24 @@
+package test_support
+
+import (
+	"strings"
+	"testing"
+)
+
+func ExpectEqual(t *testing.T, expected string, actual string) {
+	if strings.TrimSpace(expected) != strings.TrimSpace(actual) {
+		t.Errorf("Expected does not match actual, %s != %s", expected, actual)
+	}
+}
+
+func ExpectEqualInt(t *testing.T, expected int, actual int) {
+	if expected != actual {
+		t.Errorf("Expected does not match actual, %d != %d", expected, actual)
+	}
+}
+
+func ExpectNotEmpty(t *testing.T, value *map[string]string, valueName string) {
+	if len(*value) == 0 {
+		t.Errorf("%s should not be empty", valueName)
+	}
+}


### PR DESCRIPTION
- Allows instance id and region to be passed in as annotations
- Updates logic to use annotation values for instance id and region then falling back to environment variables as defaults
- Adds support for getting API_KEY from key-protect-access secret and falls back to cloud-access secret if not provided